### PR TITLE
Separate photoNFT.safeTransferFrom() by Seller->PhotoNFTMarketPlace and PhotoNFTMarketPlace->Buyer

### DIFF
--- a/contracts/PhotoNFTMarketPlace.sol
+++ b/contracts/PhotoNFTMarketPlace.sol
@@ -36,8 +36,10 @@ contract PhotoNFTMarketPlace {
 
         /// Transfer Ownership of the PhotoNFT from a seller to a buyer
         uint tokenId = 0;  /// [Note]: This time each asset is unique (only 1). Therefore, tokenId is always "0"
+        photoNFT.safeTransferFrom(seller, address(this), tokenId);      /// [Note]: Transfer from a seller to this contract (Approval of tokenId is already done when a photoNFT is created)
+
         photoNFT.approve(msg.sender, tokenId);
-        photoNFT.safeTransferFrom(seller, msg.sender, tokenId);
+        photoNFT.safeTransferFrom(address(this), msg.sender, tokenId);  /// [Note]: Transfer from this contract to a buyer
 
         /// Mint a photo with a new photoId
         //string memory tokenURI = photoNFTFactory.getTokenURI(photoData.ipfsHashOfPhoto);  /// [Note]: IPFS hash + URL


### PR DESCRIPTION
- Approval is already done. Therefore, the PhotoNFTMarketPlace contract can be supposed to receive a NFT (=approved-photoId) from seller when a buyer request buy() method  
   ↓
    - Separate photoNFT.safeTransferFrom() by：
       - Seller -> PhotoNFTMarketPlace 
       - PhotoNFTMarketPlace -> Buyer
          https://github.com/masaun/NFT-based-photo-marketplace/pull/17/commits/827585cd4c6ce36ab6239e348fc9b1b17b685024