### PR TITLE
Fix starting number of "tradeCount" with "1"

### DIFF
--- a/contracts/PhotoNFTTradable.sol
+++ b/contracts/PhotoNFTTradable.sol
@@ -34,13 +34,15 @@ contract PhotoNFTTradable {
      */
     function openTrade(PhotoNFT photoNFT, uint256 _photoId, uint256 _photoPrice) public {
         photoNFT.transferFrom(msg.sender, address(this), _photoId);
+
+        tradeCounter += 1;    /// [Note]: New. Trade count is started from "1". This is to align photoId
         trades[tradeCounter] = Trade({
             seller: msg.sender,
             photoId: _photoId,
             photoPrice: _photoPrice,
             status: "Open"
         });
-        tradeCounter += 1;
+        //tradeCounter += 1;  /// [Note]: Original
         emit TradeStatusChange(tradeCounter - 1, "Open");
     }
 


### PR DESCRIPTION
- Fix starting number of `"tradeCount"` with `"1"` ⭕️
  - Because the `tradeCount` should be aligned with `photoId`
![Screen Shot 2021-03-01 at 10 43 14](https://user-images.githubusercontent.com/19357502/109442295-1feb1c00-7a7b-11eb-9781-c0a1cf9dc1c0.png)
